### PR TITLE
Fix running Chef example device with RPC enabled on MacOS crashed: "Code is unsafe/racy"

### DIFF
--- a/examples/common/pigweed/rpc_services/Attributes.h
+++ b/examples/common/pigweed/rpc_services/Attributes.h
@@ -30,9 +30,22 @@
 #include <lib/core/CHIPTLVTags.h>
 #include <lib/core/CHIPTLVTypes.h>
 #include <platform/PlatformManager.h>
+#include <future>
 
 namespace chip {
 namespace rpc {
+
+struct WriteArgs {
+    std::promise<EmberAfStatus> *promise;
+    const chip_rpc_AttributeWrite *request;
+    const void *data;
+};
+
+struct ReadArgs {
+    std::promise<CHIP_ERROR> *promise;
+    const app::ConcreteAttributePath *path;
+    app::AttributeReportIBs::Builder *attributeReports;
+};
 
 // Implementation class for chip.rpc.Attributes.
 class Attributes : public pw_rpc::nanopb::Attributes::Service<Attributes>
@@ -41,8 +54,6 @@ public:
     ::pw::Status Write(const chip_rpc_AttributeWrite & request, pw_protobuf_Empty & response)
     {
         const void * data;
-        DeviceLayer::StackLock lock;
-
         switch (request.data.which_data)
         {
         case chip_rpc_AttributeData_data_bool_tag:
@@ -72,9 +83,28 @@ public:
         default:
             return pw::Status::InvalidArgument();
         }
-        RETURN_STATUS_IF_NOT_OK(
-            emberAfWriteAttribute(request.metadata.endpoint, request.metadata.cluster, request.metadata.attribute_id,
-                                  const_cast<uint8_t *>(static_cast<const uint8_t *>(data)), request.metadata.type));
+
+        std::promise<EmberAfStatus> writeStatusPromise;
+        WriteArgs writeArgs = {
+            .promise = &writeStatusPromise,
+            .request = &request,
+            .data = data,
+        };
+        chip::DeviceLayer::PlatformMgr().ScheduleWork([](intptr_t ctx) {
+            DeviceLayer::StackLock lock;
+
+            WriteArgs *args = reinterpret_cast<WriteArgs*>(ctx);
+            args->promise->set_value(
+                 emberAfWriteAttribute(
+                     args->request->metadata.endpoint,
+                     args->request->metadata.cluster,
+                     args->request->metadata.attribute_id,
+                     const_cast<uint8_t *>(static_cast<const uint8_t *>(args->data)),
+                     args->request->metadata.type));
+        }, reinterpret_cast<intptr_t>(&writeArgs));
+
+        RETURN_STATUS_IF_NOT_OK(writeStatusPromise.get_future().get());
+
         return pw::OkStatus();
     }
 
@@ -192,7 +222,6 @@ private:
 
     ::pw::Status ReadAttributeIntoTlvBuffer(const app::ConcreteAttributePath & path, MutableByteSpan & tlvBuffer)
     {
-        Access::SubjectDescriptor subjectDescriptor{ .authMode = chip::Access::AuthMode::kPase };
         app::AttributeReportIBs::Builder attributeReports;
         TLV::TLVWriter writer;
         TLV::TLVType outer;
@@ -201,7 +230,21 @@ private:
         writer.Init(tlvBuffer);
         PW_TRY(ChipErrorToPwStatus(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outer)));
         PW_TRY(ChipErrorToPwStatus(attributeReports.Init(&writer, kReportContextTag)));
-        PW_TRY(ChipErrorToPwStatus(app::ReadSingleClusterData(subjectDescriptor, false, path, attributeReports, nullptr)));
+
+        std::promise<CHIP_ERROR> readStatusPromise;
+        ReadArgs readArgs = {
+            .promise = &readStatusPromise,
+            .path = &path,
+            .attributeReports = &attributeReports,
+        };
+        chip::DeviceLayer::PlatformMgr().ScheduleWork([](intptr_t ctx) {
+            Access::SubjectDescriptor subjectDescriptor{ .authMode = chip::Access::AuthMode::kPase };
+            ReadArgs *args = reinterpret_cast<ReadArgs*>(ctx);
+            args->promise->set_value(app::ReadSingleClusterData(subjectDescriptor, false, *(args->path), *(args->attributeReports), nullptr));
+        }, reinterpret_cast<intptr_t>(&readArgs));
+
+        PW_TRY(ChipErrorToPwStatus(readStatusPromise.get_future().get()));
+
         attributeReports.EndOfContainer();
         PW_TRY(ChipErrorToPwStatus(writer.EndContainer(outer)));
         PW_TRY(ChipErrorToPwStatus(writer.Finalize()));


### PR DESCRIPTION
# Description

Running Chef example device with RPC enabled on MacOS,, when accessing through RPC, the process crashed and shows  **"Chip stack locking error at '../third_party/connectedhomeip/src/app/util/attribute-storage.cpp:496'. Code is unsafe/racy"** . Full logs are attached.

```
[1672985524055] [66420:2416745] CHIP: [DL] Device Configuration:
[1672985524055] [66420:2416745] CHIP: [DL]   Serial Number: TEST_SN
[1672985524055] [66420:2416745] CHIP: [DL]   Vendor Id: 65521 (0xFFF1)
[1672985524055] [66420:2416745] CHIP: [DL]   Product Id: 32768 (0x8000)
[1672985524055] [66420:2416745] CHIP: [DL]   Hardware Version: 0
[1672985524056] [66420:2416745] CHIP: [DL]   Setup Pin Code (0 for UNKNOWN/ERROR): 20202021
[1672985524056] [66420:2416745] CHIP: [DL]   Setup Discriminator (0xFFFF for UNKNOWN/ERROR): 3840 (0xF00)
[1672985524056] [66420:2416745] CHIP: [DL]   Manufacturing Date: (not set)
[1672985524056] [66420:2416745] CHIP: [DL]   Device Type: 65535 (0xFFFF)
[1672985524056] [66420:2416745] CHIP: [SVR] SetupQRCode: [MT:Y.K90AFN00KA0648G00]
[1672985524056] [66420:2416745] CHIP: [SVR] Copy/paste the below URL in a browser to see the QR Code:
[1672985524056] [66420:2416745] CHIP: [SVR] https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3AY.K90AFN00KA0648G00
[1672985524056] [66420:2416745] CHIP: [SVR] Manual pairing code: [34970112332]
[1672985524056] [66420:2416761] CHIP: [DIS] Updating services using commissioning mode 1
[1672985524056] [66420:2416761] CHIP: [DL] Using wifi MAC for hostname
[1672985524057] [66420:2416761] CHIP: [DIS] Advertise commission parameter vendorID=65521 productID=32768 discriminator=3840/15 cm=1
[1672985524057] [66420:2416761] CHIP: [DIS] Registering service F014704C4BA27EF4 on host 88665A5ACF51.local. with port 5540 and type: _matterc._udp,_V65521,_S15,_L3840,_CM on interface id: 0
[1672985524057] [66420:2416761] CHIP: [DIS] Mdns: OnRegister name: F014704C4BA27EF4, type: _matterc._udp., domain: local., flags: 2
[1672985524057] [66420:2416761] CHIP: [DIS] mDNS service published: _matterc._udp; instance name: F014704C4BA27EF4
[1672985524059] [66420:2416761] CHIP: [DIS] Status: Satisfied
[1672985524059] [66420:2416761] CHIP: [DIS]     lo0 (1)
[1672985524059] [66420:2416761] CHIP: [DIS]             * ipv6: ::1
[1672985524059] [66420:2416761] CHIP: [DIS]             * ipv6: fe80::1
[1672985524060] [66420:2416761] CHIP: [DIS]     en0 (6 / WiFi)
[1672985524060] [66420:2416761] CHIP: [DIS]             * ipv6: fe80::1827:c337:dad5:269e
[1672985524060] [66420:2416761] CHIP: [DIS]             * ipv6: fd60:8de0:2059:b8c5:4bd:a9d7:dd45:9e3
[1672985524061] [66420:2416761] CHIP: [DIS] Mdns: OnRegisterRecord flags: 1
[1672985524061] [66420:2416761] CHIP: [DIS] Mdns: OnRegisterRecord flags: 1
[1672985524061] [66420:2416761] CHIP: [DIS] Mdns: OnRegisterRecord flags: 1
[1672985524061] [66420:2416761] CHIP: [DIS] Mdns: OnRegisterRecord flags: 0
[1672985541705] [66420:2416766] CHIP: [DMG] Reading attribute: Cluster=0x0000_0006 Endpoint=1 AttributeId=0x0000_0000 (expanded=0)
[1672985541705] [66420:2416766] CHIP: [DL] Chip stack locking error at '../third_party/connectedhomeip/src/app/util/attribute-storage.cpp:496'. Code is unsafe/racy
[1672985541705] [66420:2416766] CHIP: [-] chipDie chipDie chipDie
```

# Issues
Filed in issue #9 

# Resolution:
Lock the stack (by Promise) and use the same working thread to set/get attributes
