### PR TITLE
Support --rpc-port to assign RPC port for examples.

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -254,6 +254,7 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions)
     }
 
 #if defined(PW_RPC_ENABLED)
+    rpc::SetPort(LinuxDeviceOptions::GetInstance().RpcPort);
     rpc::Init();
     ChipLogProgress(NotSpecified, "PW_RPC initialized.");
 #endif // defined(PW_RPC_ENABLED)

--- a/examples/platform/linux/CommonRpc.h
+++ b/examples/platform/linux/CommonRpc.h
@@ -22,6 +22,7 @@ namespace chip {
 namespace rpc {
 
 int Init();
+int SetPort(uint16_t port);
 
 } // namespace rpc
 } // namespace chip

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -74,6 +74,7 @@ enum
     kDeviceOption_TestEventTriggerEnableKey             = 0x101f,
     kCommissionerOption_FabricID                        = 0x1020,
     kDeviceOption_StorageSpace                          = 0x1021,
+    kDeviceOption_RpcPort                               = 0x1022,
 };
 
 constexpr unsigned kAppUsageLength = 64;
@@ -104,6 +105,7 @@ OptionDef sDeviceOptionDefs[] = {
     { "command", kArgumentRequired, kDeviceOption_Command },
     { "PICS", kArgumentRequired, kDeviceOption_PICS },
     { "storage-space", kArgumentRequired, kDeviceOption_StorageSpace },
+    { "rpc-port", kArgumentRequired, kDeviceOption_RpcPort },
     { "KVS", kArgumentRequired, kDeviceOption_KVS },
     { "interface-id", kArgumentRequired, kDeviceOption_InterfaceId },
 #if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
@@ -197,6 +199,8 @@ const char * sDeviceOptionHelp =
     "\n"
     "  --storage-space <dirpath>\n"
     "       A folder to store factory data, configs, counters\n"
+    "  --rpc-port <port>\n"
+    "       A 16-bit unsigned integer specifying the port to use for rpc communication (default is 33000).\n"
     "\n"
     "  --KVS <filepath>\n"
     "       A file to store Key Value Store items.\n"
@@ -408,6 +412,10 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
 
     case kDeviceOption_StorageSpace:
         LinuxDeviceOptions::GetInstance().StorageSpace = aValue;
+        break;
+
+    case kDeviceOption_RpcPort:
+        LinuxDeviceOptions::GetInstance().RpcPort = static_cast<uint16_t>(atoi(aValue));
         break;
 
     case kDeviceOption_KVS:

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -45,6 +45,7 @@ struct LinuxDeviceOptions
     chip::Optional<std::vector<uint8_t>> spake2pSalt;
     uint32_t spake2pIterations          = 0; // When not provided (0), will default elsewhere
     uint32_t mBleDevice                 = 0;
+    uint16_t RpcPort                    = 33000;
     bool mWiFi                          = false;
     bool mThread                        = false;
     uint32_t securedDevicePort          = CHIP_PORT;

--- a/examples/platform/linux/Rpc.cpp
+++ b/examples/platform/linux/Rpc.cpp
@@ -18,6 +18,7 @@
 
 #include "pw_rpc/server.h"
 #include "pw_rpc_system_server/rpc_server.h"
+#include "pw_rpc_system_server/socket.h"
 
 #include <thread>
 
@@ -121,6 +122,13 @@ int Init()
     int err = 0;
     std::thread rpc_service(RunRpcService);
     rpc_service.detach();
+    return err;
+}
+
+int SetPort(uint16_t port)
+{
+    int err = 0;
+    pw::rpc::system_server::set_socket_port(port);
     return err;
 }
 


### PR DESCRIPTION
This patch allowed users to assign RPC port by '--rpc-port' when executing a chef binary.