### PR TITLE
Fix RPC deadlock on Linux

### DIFF
--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -159,7 +159,7 @@ bool PlatformManagerImpl::_IsChipStackLockedByCurrentThread() const
 {
     // If we have no work queue, or it's suspended, then we assume our caller
     // knows what they are doing in terms of their own concurrency.
-    return !mWorkQueue || mIsWorkQueueSuspended || IsWorkQueueCurrentQueue();
+    return !mWorkQueue || mIsWorkQueueSuspended || IsWorkQueueCurrentQueue() || (mChipStackIsLocked && (pthread_equal(pthread_self(), mChipStackLockOwnerThread)));
 };
 #endif
 


### PR DESCRIPTION
1.  The current RPC `read` & `write` will be deadlocked due to `Stack lock;` and `ScheduleWork()` both will lock the same mutex , and the RPC tread calling `Stack lock` will also locked by `future.get()`. So we have to revert [fa4662](https://github.com/erwinpan1/connectedhomeip/commit/fa46625296f61a86b1328c8607ce56bfe1f3b177).  

3. However, this caused original issue it tried to fix shown again:  "MacOS is panic with thread unsafe when running RPC Read/Write". So we have to implement `_Unlock()`, `_Lock()`, `_TryLock()` on Mac (Darwin)