### PR TITLE
Add support for single float type in RPC.

### DIFF
--- a/examples/chef/common/chef-concentration-measurement.cpp
+++ b/examples/chef/common/chef-concentration-measurement.cpp
@@ -76,17 +76,8 @@ Protocols::InteractionModel::Status chefConcentrationMeasurementWriteCallback(
 
     if (attributeId == measuredValueId)
     {
-        float newValue  = 0;
-        uint16_t tlvLen = *(uint16_t *) buffer;
-        chip::TLV::TLVReader reader;
-        reader.Init(buffer + sizeof(uint16_t), tlvLen);
-        reader.Next();
-        reader.Get(newValue);
-
-        ChipLogDetail(DeviceLayer, "TLV Type %d, Length %d \n", static_cast<int>(reader.GetType()), tlvLen);
-        // 2 bytes buf length + 5 bytes TLV for float
-        ChipLogDetail(DeviceLayer, "buffer: %02x%02x%02x%02x%02x%02x%02x \n", buffer[0], buffer[1], buffer[2], buffer[3], buffer[4],
-                      buffer[5], buffer[6]);
+        float newValue;
+        std::memcpy(&newValue, buffer, sizeof(float)); // Copy buffer content to float
 
         CHIP_ERROR err = clusterInstance->SetMeasuredValue(MakeNullable(newValue));
         if (CHIP_NO_ERROR == err)

--- a/examples/common/pigweed/protos/attributes_service.proto
+++ b/examples/common/pigweed/protos/attributes_service.proto
@@ -228,6 +228,7 @@ message AttributeData {
     int32 data_int8 = 6;
     int32 data_int16 = 7;
     int32 data_int32 = 8;
+    float data_single = 10;
   };
   optional bytes tlv_data = 9;
 }

--- a/examples/common/pigweed/rpc_services/Attributes.h
+++ b/examples/common/pigweed/rpc_services/Attributes.h
@@ -70,6 +70,9 @@ public:
         case chip_rpc_AttributeData_data_bytes_tag:
             data = &request.data.data.data_bytes;
             break;
+        case chip_rpc_AttributeData_data_single_tag:
+            data = &request.data.data.data_single;
+            break;
         default:
             return pw::Status::InvalidArgument();
         }
@@ -125,6 +128,10 @@ public:
             PW_TRY(TlvBufferGetData(tlvBuffer, TLV::kTLVType_SignedInteger, response.data.data_int32));
             response.which_data = chip_rpc_AttributeData_data_int32_tag;
             break;
+        case chip_rpc_AttributeType_ZCL_SINGLE_ATTRIBUTE_TYPE:
+            PW_TRY(TlvBufferGetData(tlvBuffer, TLV::kTLVType_FloatingPointNumber, response.data.data_single));
+            response.which_data = chip_rpc_AttributeData_data_single_tag;
+            break;
         case chip_rpc_AttributeType_ZCL_BITMAP8_ATTRIBUTE_TYPE:
         case chip_rpc_AttributeType_ZCL_BITMAP16_ATTRIBUTE_TYPE:
         case chip_rpc_AttributeType_ZCL_BITMAP32_ATTRIBUTE_TYPE:
@@ -140,7 +147,6 @@ public:
         case chip_rpc_AttributeType_ZCL_INT48S_ATTRIBUTE_TYPE:
         case chip_rpc_AttributeType_ZCL_INT56S_ATTRIBUTE_TYPE:
         case chip_rpc_AttributeType_ZCL_INT64S_ATTRIBUTE_TYPE:
-        case chip_rpc_AttributeType_ZCL_SINGLE_ATTRIBUTE_TYPE:
         case chip_rpc_AttributeType_ZCL_DOUBLE_ATTRIBUTE_TYPE:
         case chip_rpc_AttributeType_ZCL_OCTET_STRING_ATTRIBUTE_TYPE:
         case chip_rpc_AttributeType_ZCL_CHAR_STRING_ATTRIBUTE_TYPE:


### PR DESCRIPTION
The Concentration Measurement cluster is now able to directly read and write the data value rather than wrapping the data in the TLV.

https://screenshot.googleplex.com/32U2ZGHrnXc4fnJ
![image](https://github.com/user-attachments/assets/c93a7766-f545-4adc-8dd3-e98f28546bdd)
