### PR TITLE
Mvd 3rd fix rvc crash due to countdowntime

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,14 +24,14 @@ on:
         run-codeql:
           required: false
           type: boolean
-    
+
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
     cancel-in-progress: true
 
 env:
     CHIP_NO_LOG_TIMESTAMPS: true
-    
+
 jobs:
     build_linux_gcc_debug:
         name: Build on Linux (gcc_debug)
@@ -206,7 +206,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "./scripts/run-clang-tidy-on-compile-commands.py \
                        --compile-database out/sanitizers/compile_commands.json \
-                       --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/|-ReadImpl|-InvokeSubscribeImpl' \
+                       --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/|-ReadImpl|-InvokeSubscribeImpl|CodegenDataModel_Write|QuieterReporting' \
                        check \
                     "
             - name: Clean output
@@ -239,7 +239,7 @@ jobs:
               run: |
                   rm -rf ./zzz_pregenerated
                   mv scripts/codegen.py.renamed scripts/codegen.py
-                  mv scripts/tools/zap/generate.py.renamed scripts/tools/zap/generate.py 
+                  mv scripts/tools/zap/generate.py.renamed scripts/tools/zap/generate.py
             - name: Run fake linux tests with build_examples
               run: |
                   ./scripts/run_in_build_env.sh \
@@ -249,7 +249,7 @@ jobs:
               uses: ./.github/actions/perform-codeql-analysis
               with:
                 language: cpp
-        
+
             - name: Uploading core files
               uses: actions/upload-artifact@v4
               if: ${{ failure() && !env.ACT }}
@@ -424,6 +424,10 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                     "./scripts/run-clang-tidy-on-compile-commands.py \
                        --compile-database out/default/compile_commands.json \
+<<<<<<< HEAD
+=======
+                       --file-exclude-regex '/(repo|zzz_generated|lwip/standalone)/|CodegenDataModel_Write|QuieterReporting' \
+>>>>>>> f83d67bac4 (Introduce a building block usable for all Q attributes (#34266))
                        check \
                     "
             - name: Uploading diagnostic logs
@@ -438,7 +442,7 @@ jobs:
               uses: ./.github/actions/perform-codeql-analysis
               with:
                 language: cpp
-        
+
             # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227
             # TODO https://github.com/project-chip/connectedhomeip/issues/1512
 

--- a/examples/chef/common/chef-rvc-operational-state-delegate.h
+++ b/examples/chef/common/chef-rvc-operational-state-delegate.h
@@ -95,7 +95,8 @@ public:
 
     uint32_t mRunningTime = 0;
     uint32_t mPausedTime  = 0;
-    app::DataModel::Nullable<uint32_t> mPhaseDuration;
+    app::DataModel::Nullable<uint32_t> mCountdownTime;
+    const uint32_t kExampleCountDown = 30;
 
 private:
     Span<const OperationalState::GenericOperationalState> mOperationalStateList;

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -55,6 +55,9 @@ if (chip_build_tests) {
   chip_test_group("tests") {
     deps = []
     tests = [
+      "${chip_root}/src/app/data-model/tests",
+      "${chip_root}/src/app/cluster-building-blocks/tests",
+      "${chip_root}/src/app/data-model-interface/tests",
       "${chip_root}/src/access/tests",
       "${chip_root}/src/crypto/tests",
       "${chip_root}/src/inet/tests",

--- a/src/app/cluster-building-blocks/BUILD.gn
+++ b/src/app/cluster-building-blocks/BUILD.gn
@@ -1,0 +1,24 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import("//build_overrides/chip.gni")
+
+source_set("cluster-building-blocks") {
+  sources = [ "QuieterReporting.h" ]
+
+  public_deps = [
+    "${chip_root}/src/app/data-model:nullable",
+    "${chip_root}/src/lib/support:support",
+    "${chip_root}/src/system",
+  ]
+}

--- a/src/app/cluster-building-blocks/QuieterReporting.h
+++ b/src/app/cluster-building-blocks/QuieterReporting.h
@@ -178,9 +178,9 @@ public:
         bool isChangeOfNull       = newValue.IsNull() ^ mValue.IsNull();
         bool areBothValuesNonNull = !newValue.IsNull() && !mValue.IsNull();
 
-        bool changeToFromZero = areBothValuesNonNull && (*newValue == 0 || *mValue == 0);
-        bool isIncrement      = areBothValuesNonNull && (*newValue > *mValue);
-        bool isDecrement      = areBothValuesNonNull && (*newValue < *mValue);
+        bool changeToFromZero = areBothValuesNonNull && (newValue.Value() == 0 || mValue.Value() == 0);
+        bool isIncrement      = areBothValuesNonNull && (newValue.Value() > mValue.Value());
+        bool isDecrement      = areBothValuesNonNull && (newValue.Value() < mValue.Value());
 
         bool isNewlyDirty = isChangeOfNull;
         isNewlyDirty =

--- a/src/app/cluster-building-blocks/QuieterReporting.h
+++ b/src/app/cluster-building-blocks/QuieterReporting.h
@@ -142,15 +142,6 @@ public:
         };
     }
 
-    /**
-     * @brief Factory to generate a functor that forces reportable now.
-     * @return a functor usable for the `changedPredicate` arg of `SetValue()`
-     */
-    static SufficientChangePredicate GetForceReportablePredicate()
-    {
-        return [](const SufficientChangePredicateCandidate & candidate) -> bool { return true; };
-    }
-
     Nullable<T> value() const { return mValue; }
     QuieterReportingPolicyFlags & policy() { return mPolicyFlags; }
     const QuieterReportingPolicyFlags & policy() const { return mPolicyFlags; }
@@ -163,6 +154,7 @@ public:
      * - The policies from `QuieterReportingPolicyEnum` and set via `SetPolicy()` are self-explanatory by name.
      * - The changedPredicate will be called with last dirty <timestamp, value> and new <timestamp value> and may override
      *   the dirty state altogether when it returns true. Use sparingly and default to a functor returning false.
+     *   The changedPredicate is only called on change.
      *
      * Internal recording will be done about last dirty value and last dirty timestamp based on the policies having applied.
      *
@@ -172,13 +164,13 @@ public:
      * @return AttributeDirtyState::kMustReport if attribute must be marked dirty right away, or
      * AttributeDirtyState::kNoReportNeeded otherwise.
      */
-    AttributeDirtyState SetValue(const chip::app::DataModel::Nullable<T> & newValue, Timestamp now,
-                                 SufficientChangePredicate changedPredicate)
+    AttributeDirtyState SetValue(const DataModel::Nullable<T> & newValue, Timestamp now, SufficientChangePredicate changedPredicate)
     {
-        bool isChangeOfNull       = newValue.IsNull() ^ mValue.IsNull();
-        bool areBothValuesNonNull = !newValue.IsNull() && !mValue.IsNull();
+        bool isChangeOfNull         = newValue.IsNull() != mValue.IsNull();
+        bool areBothValuesNonNull   = !newValue.IsNull() && !mValue.IsNull();
+        bool areBothValuesDifferent = areBothValuesNonNull && (newValue.Value() != mValue.Value());
 
-        bool changeToFromZero = areBothValuesNonNull && (newValue.Value() == 0 || mValue.Value() == 0);
+        bool changeToFromZero = areBothValuesNonNull && areBothValuesDifferent && (newValue.Value() == 0 || mValue.Value() == 0);
         bool isIncrement      = areBothValuesNonNull && (newValue.Value() > mValue.Value());
         bool isDecrement      = areBothValuesNonNull && (newValue.Value() < mValue.Value());
 
@@ -188,13 +180,17 @@ public:
         isNewlyDirty = isNewlyDirty || (mPolicyFlags.Has(QuieterReportingPolicyEnum::kMarkDirtyOnDecrement) && isDecrement);
         isNewlyDirty = isNewlyDirty || (mPolicyFlags.Has(QuieterReportingPolicyEnum::kMarkDirtyOnIncrement) && isIncrement);
 
-        SufficientChangePredicateCandidate candidate{
-            mLastDirtyTimestampMillis, // lastDirtyTimestamp
-            now,                       // nowTimestamp
-            mLastDirtyValue,           // lastDirtyValue
-            newValue                   // newValue
-        };
-        isNewlyDirty = isNewlyDirty || changedPredicate(candidate);
+        // Only execute predicate on value change from last marked dirty.
+        if (newValue != mLastDirtyValue)
+        {
+            SufficientChangePredicateCandidate candidate{
+                mLastDirtyTimestampMillis, // lastDirtyTimestamp
+                now,                       // nowTimestamp
+                mLastDirtyValue,           // lastDirtyValue
+                newValue                   // newValue
+            };
+            isNewlyDirty = isNewlyDirty || changedPredicate(candidate);
+        }
 
         mValue = newValue;
 
@@ -217,20 +213,20 @@ public:
      * @return AttributeDirtyState::kMustReport if attribute must be marked dirty right away, or
      * AttributeDirtyState::kNoReportNeeded otherwise.
      */
-    AttributeDirtyState SetValue(const chip::app::DataModel::Nullable<T> & newValue, Timestamp now)
+    AttributeDirtyState SetValue(const DataModel::Nullable<T> & newValue, Timestamp now)
     {
         return SetValue(newValue, now, [](const SufficientChangePredicateCandidate &) -> bool { return false; });
     }
 
 protected:
     // Current value of the attribute.
-    chip::app::DataModel::Nullable<T> mValue;
+    DataModel::Nullable<T> mValue;
     // Last value that was marked as dirty (to use in comparisons for change, e.g. by SufficientChangePredicate).
-    chip::app::DataModel::Nullable<T> mLastDirtyValue;
+    DataModel::Nullable<T> mLastDirtyValue;
     // Enabled internal change detection policies.
     QuieterReportingPolicyFlags mPolicyFlags{ 0 };
     // Timestamp associated with the last time the attribute was marked dirty (to use in comparisons for change).
-    chip::System::Clock::Milliseconds64 mLastDirtyTimestampMillis{};
+    chip::System::Clock::Timestamp mLastDirtyTimestampMillis{};
 };
 
 } // namespace detail

--- a/src/app/cluster-building-blocks/QuieterReporting.h
+++ b/src/app/cluster-building-blocks/QuieterReporting.h
@@ -1,0 +1,241 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <stdbool.h>
+#include <type_traits>
+
+#include <app/data-model/Nullable.h>
+#include <lib/support/BitFlags.h>
+#include <system/SystemClock.h>
+
+namespace chip {
+namespace app {
+
+enum class QuieterReportingPolicyEnum
+{
+    kMarkDirtyOnChangeToFromZero = (1u << 0),
+    kMarkDirtyOnDecrement        = (1u << 1),
+    kMarkDirtyOnIncrement        = (1u << 2),
+};
+
+enum class AttributeDirtyState
+{
+    kNoReportNeeded = 0,
+    kMustReport     = 1,
+};
+
+using QuieterReportingPolicyFlags = BitFlags<QuieterReportingPolicyEnum>;
+
+namespace detail {
+
+using Timestamp = System::Clock::Milliseconds64;
+template <typename T>
+using Nullable = DataModel::Nullable<T>;
+
+/**
+ * This class helps track reporting state of an attribute to properly keep track of whether
+ * it needs to be marked as dirty or not for purposes of reporting using
+ * "7.7.9 Quieter Reporting Quality" (Q quality)
+ *
+ * The class can be configured via `policy()` to have some/all of the common reasons
+ * for reporting (e.g. increment only, decrement only, change to/from zero).
+ *
+ * Changes of null to non-null or non-null to null are always considered dirty.
+ *
+ * It is possible to force mark the attribute as dirty (see `ForceDirty()`) such as
+ * for conditions like "When there is any increase or decrease in the estimated time
+ * remaining that was due to progressing insight of the server's control logic".
+ *
+ * Class maintains a `current value` and a timestamped `dirty` state. The `SetValue()`
+ * method must be used to update the `current value` and will return AttributeDirtyState::kMustReport
+ * if the attribute should be marked dirty/
+ *
+ * - `SetValue()` has internal rules for null/non-null changes and policy-based rules
+ * - `SetValue()` with a `SufficientChangePredicate` uses the internal rules in addition to
+ *    the predicate to determine dirty state
+ *
+ * See [QuieterReportingPolicyEnum] for policy flags on when a value is considered dirty
+ * beyond non/non-null changes.
+ *
+ * Common quieter reporting usecases that can be supported by this class are:
+ * - If attribute has changed due to a change in the X or Y attributes
+ *   - Use SufficientChangePredicate version
+ * - When it changes from 0 to any other value and vice versa
+ *   - Use `kMarkDirtyOnChangeToFromZero` internal policy.
+ * - When it changes from null to any other value and vice versa
+ *   - Built-in rule.
+ * - When it increases
+ *   - Use `kMarkDirtyOnIncrement` internal policy.
+ * - When it decreases
+ *   - Use `kMarkDirtyOnDecrement` internal policy.
+ * - When there is any increase or decrease in the estimated time remaining that was
+ *   due to progressing insight of the server's control logic
+ *   - Use SufficientChangePredicate version with an always-true predicate.
+ * - When it changes at a rate significantly different from one unit per second.
+ *   - Use SufficientChangePredicate version.
+ * Example usage in-situ:
+ *
+ * Class has:
+ *     QuieterReportingAttribute<uint8_t> mAttrib;
+ *
+ * Code at time of setting new value has:
+ *
+ *     uint8_t newValue = driver.GetNewValue();
+ *     auto now = SystemClock().GetMonotonicTimestamp();
+ *     if (mAttrib.SetValue(newValue, now) == AttributeDirtyState::kMustReport)
+ *     {
+ *         MatterReportingAttributeChangeCallback(path_for_attribute);
+ *     }
+ *
+ * @tparam T - the type of underlying numerical value that will be held by the class.
+ */
+template <typename T, std::enable_if_t<std::is_arithmetic<T>::value, bool> = true>
+class QuieterReportingAttribute
+{
+public:
+    explicit QuieterReportingAttribute(const Nullable<T> & initialValue) : mValue(initialValue), mLastDirtyValue(initialValue) {}
+
+    struct SufficientChangePredicateCandidate
+    {
+        // Timestamp of last time attribute was marked dirty.
+        Timestamp lastDirtyTimestamp;
+        // New (`now`) timestamp passed in `SetValue()`.
+        Timestamp nowTimestamp;
+        // Value last marked as dirty.
+        const Nullable<T> & lastDirtyValue;
+        // New value passed in `SetValue()`, to compare against lastDirtyValue for sufficient change if needed.
+        const Nullable<T> & newValue;
+    };
+
+    using SufficientChangePredicate = std::function<bool(const SufficientChangePredicateCandidate &)>;
+
+    /**
+     * @brief Factory to generate a functor for "attribute was last reported" at least `minimumDurationMillis` ago.
+     *
+     * @param minimumDurationMillis - number of millis needed since last marked as dirty before we mark dirty again.
+     * @return a functor usable for the `changedPredicate` arg of `SetValue()`
+     */
+    static SufficientChangePredicate
+    GetPredicateForSufficientTimeSinceLastDirty(System::Clock::Milliseconds64 minimumDurationMillis)
+    {
+        return [minimumDurationMillis](const SufficientChangePredicateCandidate & candidate) -> bool {
+            return (candidate.lastDirtyValue != candidate.newValue) &&
+                ((candidate.nowTimestamp - candidate.lastDirtyTimestamp) >= minimumDurationMillis);
+        };
+    }
+
+    /**
+     * @brief Factory to generate a functor that forces reportable now.
+     * @return a functor usable for the `changedPredicate` arg of `SetValue()`
+     */
+    static SufficientChangePredicate GetForceReportablePredicate()
+    {
+        return [](const SufficientChangePredicateCandidate & candidate) -> bool { return true; };
+    }
+
+    Nullable<T> value() const { return mValue; }
+    QuieterReportingPolicyFlags & policy() { return mPolicyFlags; }
+    const QuieterReportingPolicyFlags & policy() const { return mPolicyFlags; }
+
+    /**
+     * Set the updated value of the attribute, computing whether it needs to be reported according to `changedPredicate` and
+     * policies.
+     *
+     * - Any change of nullability between `newValue` and the old value will be considered dirty.
+     * - The policies from `QuieterReportingPolicyEnum` and set via `SetPolicy()` are self-explanatory by name.
+     * - The changedPredicate will be called with last dirty <timestamp, value> and new <timestamp value> and may override
+     *   the dirty state altogether when it returns true. Use sparingly and default to a functor returning false.
+     *
+     * Internal recording will be done about last dirty value and last dirty timestamp based on the policies having applied.
+     *
+     * @param newValue - new value to set for the attribute
+     * @param now - system monotonic timestamp at the time of the call
+     * @param changedPredicate - functor to possibly override dirty state
+     * @return AttributeDirtyState::kMustReport if attribute must be marked dirty right away, or
+     * AttributeDirtyState::kNoReportNeeded otherwise.
+     */
+    AttributeDirtyState SetValue(const chip::app::DataModel::Nullable<T> & newValue, Timestamp now,
+                                 SufficientChangePredicate changedPredicate)
+    {
+        bool isChangeOfNull       = newValue.IsNull() ^ mValue.IsNull();
+        bool areBothValuesNonNull = !newValue.IsNull() && !mValue.IsNull();
+
+        bool changeToFromZero = areBothValuesNonNull && (*newValue == 0 || *mValue == 0);
+        bool isIncrement      = areBothValuesNonNull && (*newValue > *mValue);
+        bool isDecrement      = areBothValuesNonNull && (*newValue < *mValue);
+
+        bool isNewlyDirty = isChangeOfNull;
+        isNewlyDirty =
+            isNewlyDirty || (mPolicyFlags.Has(QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero) && changeToFromZero);
+        isNewlyDirty = isNewlyDirty || (mPolicyFlags.Has(QuieterReportingPolicyEnum::kMarkDirtyOnDecrement) && isDecrement);
+        isNewlyDirty = isNewlyDirty || (mPolicyFlags.Has(QuieterReportingPolicyEnum::kMarkDirtyOnIncrement) && isIncrement);
+
+        SufficientChangePredicateCandidate candidate{
+            mLastDirtyTimestampMillis, // lastDirtyTimestamp
+            now,                       // nowTimestamp
+            mLastDirtyValue,           // lastDirtyValue
+            newValue                   // newValue
+        };
+        isNewlyDirty = isNewlyDirty || changedPredicate(candidate);
+
+        mValue = newValue;
+
+        if (isNewlyDirty)
+        {
+            mLastDirtyValue           = newValue;
+            mLastDirtyTimestampMillis = now;
+        }
+
+        return isNewlyDirty ? AttributeDirtyState::kMustReport : AttributeDirtyState::kNoReportNeeded;
+    }
+
+    /**
+     * Same as the other `SetValue`, but assumes a changedPredicate that never overrides to dirty.
+     *
+     * This is the easy/common case.
+     *
+     * @param newValue - new value to set for the attribute
+     * @param now - system monotonic timestamp at the time of the call
+     * @return AttributeDirtyState::kMustReport if attribute must be marked dirty right away, or
+     * AttributeDirtyState::kNoReportNeeded otherwise.
+     */
+    AttributeDirtyState SetValue(const chip::app::DataModel::Nullable<T> & newValue, Timestamp now)
+    {
+        return SetValue(newValue, now, [](const SufficientChangePredicateCandidate &) -> bool { return false; });
+    }
+
+protected:
+    // Current value of the attribute.
+    chip::app::DataModel::Nullable<T> mValue;
+    // Last value that was marked as dirty (to use in comparisons for change, e.g. by SufficientChangePredicate).
+    chip::app::DataModel::Nullable<T> mLastDirtyValue;
+    // Enabled internal change detection policies.
+    QuieterReportingPolicyFlags mPolicyFlags{ 0 };
+    // Timestamp associated with the last time the attribute was marked dirty (to use in comparisons for change).
+    chip::System::Clock::Milliseconds64 mLastDirtyTimestampMillis{};
+};
+
+} // namespace detail
+
+using detail::QuieterReportingAttribute;
+
+} // namespace app
+} // namespace chip

--- a/src/app/cluster-building-blocks/tests/BUILD.gn
+++ b/src/app/cluster-building-blocks/tests/BUILD.gn
@@ -1,0 +1,30 @@
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+import("${chip_root}/build/chip/chip_test_suite.gni")
+
+chip_test_suite("tests") {
+  output_name = "libAppClusterBuildingBlockTests"
+
+  test_sources = [ "TestQuieterReporting.cpp" ]
+
+  public_deps = [
+    "${chip_root}/src/app/cluster-building-blocks",
+    "${chip_root}/src/app/data-model:nullable",
+    "${chip_root}/src/lib/core:error",
+    "${chip_root}/src/lib/support/tests:pw-test-macros",
+    "${chip_root}/src/system",
+  ]
+}

--- a/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
+++ b/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
@@ -1,0 +1,262 @@
+/*
+ *
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/cluster-building-blocks/QuieterReporting.h>
+
+#include <limits.h>
+
+#include <app/data-model/Nullable.h>
+#include <lib/core/CHIPError.h>
+#include <system/SystemClock.h>
+
+#include <gtest/gtest.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::app::DataModel;
+using namespace chip::System::Clock;
+using namespace chip::System::Clock::Literals;
+
+class FakeClock
+{
+public:
+    FakeClock() = default;
+
+    Timestamp Advance(Milliseconds64 numMillis)
+    {
+        mCurrentTimestamp += numMillis;
+        return mCurrentTimestamp;
+    }
+
+    void SetMonotonic(Timestamp now) { mCurrentTimestamp = now; }
+
+    Timestamp now() const { return mCurrentTimestamp; }
+
+private:
+    Timestamp mCurrentTimestamp{};
+};
+
+TEST(TestQuieterReporting, ChangeToFromZeroPolicyWorks)
+{
+    FakeClock fakeClock;
+    fakeClock.SetMonotonic(100_ms);
+
+    QuieterReportingAttribute<int> attribute{ MakeNullable<int>(10) };
+    EXPECT_FALSE(attribute.value().IsNull());
+    EXPECT_EQ(attribute.policy(), QuieterReportingPolicyFlags{});
+
+    auto now = fakeClock.now();
+
+    attribute.policy().Set(QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero);
+    EXPECT_TRUE(attribute.policy().HasOnly(QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero));
+
+    // 10 --> 11, expect not marked dirty yet.
+    EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+
+    // 11 --> 0, expect marked dirty.
+    EXPECT_EQ(attribute.SetValue(0, now), AttributeDirtyState::kMustReport);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 0);
+
+    // 0 --> 11, expect marked dirty.
+    EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kMustReport);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+
+    // 11 --> 12, expect not marked dirty.
+    EXPECT_EQ(attribute.SetValue(12, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
+
+    // Reset policy, expect 12 --> 0 does not mark dirty due to no longer having the policy that causes it.
+    attribute.policy().ClearAll();
+    EXPECT_FALSE(attribute.policy().HasAny());
+
+    EXPECT_EQ(attribute.SetValue(0, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 0);
+}
+
+TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
+{
+    FakeClock fakeClock;
+    fakeClock.SetMonotonic(100_ms);
+
+    QuieterReportingAttribute<int> attribute{ MakeNullable<int>(10) };
+
+    // Always start not dirty (because first sub priming always just read value anyway).
+    ASSERT_EQ(*attribute.value(), 10);
+
+    auto now = fakeClock.now();
+
+    attribute.policy().Set(QuieterReportingPolicyEnum::kMarkDirtyOnIncrement);
+    EXPECT_TRUE(attribute.policy().HasOnly(QuieterReportingPolicyEnum::kMarkDirtyOnIncrement));
+
+    // 10 --> 9, expect not marked dirty yet.
+    EXPECT_EQ(attribute.SetValue(9, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 9);
+
+    // 9 --> 10, expect marked dirty.
+    EXPECT_EQ(attribute.SetValue(10, now), AttributeDirtyState::kMustReport);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
+
+    // 10 --> 11, expect marked dirty.
+    EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kMustReport);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+
+    // 11 --> 11, expect marked not dirty.
+    EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+
+    // 11 --> null, expect marked dirty (null change always marks dirty)
+    EXPECT_EQ(attribute.SetValue(NullNullable, now), AttributeDirtyState::kMustReport);
+    EXPECT_TRUE(attribute.value().IsNull());
+
+    // null --> null, not dirty (no change)
+    EXPECT_EQ(attribute.SetValue(NullNullable, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_TRUE(attribute.value().IsNull());
+
+    // null --> 11, expect marked dirty (null change always marks dirty).
+    EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kMustReport);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+
+    // Reset policy, expect 11 --> 12 does not mark dirty due to no longer having the policy that causes it.
+    attribute.policy().ClearAll();
+    EXPECT_FALSE(attribute.policy().HasAny());
+
+    EXPECT_EQ(attribute.SetValue(12, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
+}
+
+TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
+{
+    FakeClock fakeClock;
+    fakeClock.SetMonotonic(100_ms);
+
+    QuieterReportingAttribute<int> attribute{ MakeNullable<int>(9) };
+
+    // Always start not dirty (because first sub priming always just read value anyway).
+    ASSERT_EQ(*attribute.value(), 9);
+
+    auto now = fakeClock.now();
+
+    attribute.policy().Set(QuieterReportingPolicyEnum::kMarkDirtyOnDecrement);
+    EXPECT_TRUE(attribute.policy().HasOnly(QuieterReportingPolicyEnum::kMarkDirtyOnDecrement));
+
+    // 9 --> 10, expect not marked dirty yet.
+    EXPECT_EQ(attribute.SetValue(10, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
+
+    // 10 --> 9, expect marked dirty.
+    EXPECT_EQ(attribute.SetValue(9, now), AttributeDirtyState::kMustReport);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 9);
+
+    // 9 --> 8, expect marked dirty.
+    EXPECT_EQ(attribute.SetValue(8, now), AttributeDirtyState::kMustReport);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 8);
+
+    // Second call in a row always false.
+
+    // 8 --> 8, expect not marked dirty.
+    EXPECT_EQ(attribute.SetValue(8, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 8);
+
+    // 8 --> null, expect marked dirty (null change always marks dirty)
+    EXPECT_EQ(attribute.SetValue(NullNullable, now), AttributeDirtyState::kMustReport);
+    EXPECT_TRUE(attribute.value().IsNull());
+
+    // null --> null, not dirty (no change)
+    EXPECT_EQ(attribute.SetValue(NullNullable, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_TRUE(attribute.value().IsNull());
+
+    // null --> 11, expect marked dirty (null change always marks dirty).
+    EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kMustReport);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+
+    // Reset policy, expect 11 --> 10 does not mark dirty due to no longer having the policy that causes it.
+    attribute.policy().ClearAll();
+    EXPECT_FALSE(attribute.policy().HasAny());
+
+    EXPECT_EQ(attribute.SetValue(10, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
+}
+
+TEST(TestQuieterReporting, SufficientChangePredicateWorks)
+{
+    FakeClock fakeClock;
+    fakeClock.SetMonotonic(100_ms);
+
+    QuieterReportingAttribute<int> attribute{ MakeNullable<int>(9) };
+
+    // Always start not dirty (because first sub priming always just read value anyway).
+    ASSERT_EQ(*attribute.value(), 9);
+
+    auto now = fakeClock.now();
+
+    EXPECT_EQ(attribute.SetValue(10, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
+
+    // Forcing dirty can be done with a force-true predicate
+    EXPECT_EQ(attribute.SetValue(10, now, attribute.GetForceReportablePredicate()), AttributeDirtyState::kMustReport);
+
+    auto predicate = attribute.GetPredicateForSufficientTimeSinceLastDirty(1000_ms);
+
+    now = fakeClock.Advance(100_ms);
+
+    // Last dirty value is 10. This won't mark dirty again due to predicate mismatch.
+    EXPECT_EQ(attribute.SetValue(11, now, predicate), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+
+    now = fakeClock.Advance(900_ms);
+    // Last dirty value is 10 still. This will mark dirty because both enough time has passed
+    // and value is different from the last dirty value.
+    EXPECT_EQ(attribute.SetValue(11, now, predicate), AttributeDirtyState::kMustReport);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+
+    // Last dirty value is 11. Since there has not been a value change, no amount of time will
+    // mark dirty.
+    now = fakeClock.Advance(1000_ms);
+    EXPECT_EQ(attribute.SetValue(11, now, predicate), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+
+    now = fakeClock.Advance(1000_ms);
+    EXPECT_EQ(attribute.SetValue(11, now, predicate), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
+
+    // Change the value to a value that marks dirty.
+    now = fakeClock.Advance(1_ms);
+    EXPECT_EQ(attribute.SetValue(12, now, predicate), AttributeDirtyState::kMustReport);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
+
+    // Wait a small delay and change again. Will not mark dirty due to too little time.
+    now = fakeClock.Advance(1_ms);
+    EXPECT_EQ(attribute.SetValue(13, now, predicate), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 13);
+
+    now = fakeClock.Advance(1_ms);
+    EXPECT_EQ(attribute.SetValue(14, now, predicate), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 14);
+
+    // Change to a value that marks dirty no matter what (e.g. null). Should be dirty even
+    // before delay.
+    now = fakeClock.Advance(1_ms);
+    EXPECT_EQ(attribute.SetValue(NullNullable, now, predicate), AttributeDirtyState::kMustReport);
+    EXPECT_TRUE(attribute.value().IsNull());
+
+    // Null --> Null should not lead to dirty.
+    now = fakeClock.Advance(1000_ms);
+    EXPECT_EQ(attribute.SetValue(NullNullable, now, predicate), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_TRUE(attribute.value().IsNull());
+}

--- a/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
+++ b/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
@@ -97,7 +97,7 @@ TEST(TestQuieterReporting, ChangeOnIncrementPolicyWorks)
     QuieterReportingAttribute<int> attribute{ MakeNullable<int>(10) };
 
     // Always start not dirty (because first sub priming always just read value anyway).
-    ASSERT_EQ(*attribute.value(), 10);
+    ASSERT_EQ(attribute.value().Value(), 10);
 
     auto now = fakeClock.now();
 
@@ -148,7 +148,7 @@ TEST(TestQuieterReporting, ChangeOnDecrementPolicyWorks)
     QuieterReportingAttribute<int> attribute{ MakeNullable<int>(9) };
 
     // Always start not dirty (because first sub priming always just read value anyway).
-    ASSERT_EQ(*attribute.value(), 9);
+    ASSERT_EQ(attribute.value().Value(), 9);
 
     auto now = fakeClock.now();
 
@@ -201,7 +201,7 @@ TEST(TestQuieterReporting, SufficientChangePredicateWorks)
     QuieterReportingAttribute<int> attribute{ MakeNullable<int>(9) };
 
     // Always start not dirty (because first sub priming always just read value anyway).
-    ASSERT_EQ(*attribute.value(), 9);
+    ASSERT_EQ(attribute.value().Value(), 9);
 
     auto now = fakeClock.now();
 

--- a/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
+++ b/src/app/cluster-building-blocks/tests/TestQuieterReporting.cpp
@@ -73,6 +73,10 @@ TEST(TestQuieterReporting, ChangeToFromZeroPolicyWorks)
     EXPECT_EQ(attribute.SetValue(0, now), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 0);
 
+    // 0 --> 0, expect NOT marked dirty.
+    EXPECT_EQ(attribute.SetValue(0, now), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 0);
+
     // 0 --> 11, expect marked dirty.
     EXPECT_EQ(attribute.SetValue(11, now), AttributeDirtyState::kMustReport);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 11);
@@ -208,9 +212,6 @@ TEST(TestQuieterReporting, SufficientChangePredicateWorks)
     EXPECT_EQ(attribute.SetValue(10, now), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 10);
 
-    // Forcing dirty can be done with a force-true predicate
-    EXPECT_EQ(attribute.SetValue(10, now, attribute.GetForceReportablePredicate()), AttributeDirtyState::kMustReport);
-
     auto predicate = attribute.GetPredicateForSufficientTimeSinceLastDirty(1000_ms);
 
     now = fakeClock.Advance(100_ms);
@@ -248,6 +249,14 @@ TEST(TestQuieterReporting, SufficientChangePredicateWorks)
     now = fakeClock.Advance(1_ms);
     EXPECT_EQ(attribute.SetValue(14, now, predicate), AttributeDirtyState::kNoReportNeeded);
     EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 14);
+
+    // Forcing dirty can NOT done with a force-true predicate.
+    decltype(attribute)::SufficientChangePredicate forceTruePredicate{
+        [](const decltype(attribute)::SufficientChangePredicateCandidate &) -> bool { return true; }
+    };
+    now = fakeClock.Advance(1_ms);
+    EXPECT_EQ(attribute.SetValue(12, now, forceTruePredicate), AttributeDirtyState::kNoReportNeeded);
+    EXPECT_EQ(attribute.value().ValueOr(INT_MAX), 12);
 
     // Change to a value that marks dirty no matter what (e.g. null). Should be dirty even
     // before delay.

--- a/src/app/clusters/operational-state-server/operational-state-server.cpp
+++ b/src/app/clusters/operational-state-server/operational-state-server.cpp
@@ -26,6 +26,7 @@
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/reporting.h>
 #include <app/util/attribute-storage.h>
+#include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip;
 using namespace chip::app;
@@ -40,6 +41,9 @@ Instance::Instance(Delegate * aDelegate, EndpointId aEndpointId, ClusterId aClus
     mDelegate(aDelegate), mEndpointId(aEndpointId), mClusterId(aClusterId)
 {
     mDelegate->SetInstance(this);
+    mCountdownTime.policy()
+        .Set(QuieterReportingPolicyEnum::kMarkDirtyOnIncrement)
+        .Set(QuieterReportingPolicyEnum::kMarkDirtyOnChangeToFromZero);
 }
 
 Instance::Instance(Delegate * aDelegate, EndpointId aEndpointId) : Instance(aDelegate, aEndpointId, OperationalState::Id) {}
@@ -81,6 +85,7 @@ CHIP_ERROR Instance::SetCurrentPhase(const DataModel::Nullable<uint8_t> & aPhase
     if (mCurrentPhase != oldPhase)
     {
         MatterReportingAttributeChangeCallback(mEndpointId, mClusterId, Attributes::CurrentPhase::Id);
+        UpdateCountdownTimeFromClusterLogic();
     }
     return CHIP_NO_ERROR;
 }
@@ -93,9 +98,11 @@ CHIP_ERROR Instance::SetOperationalState(uint8_t aOpState)
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 
+    bool countdownTimeUpdateNeeded = false;
     if (mOperationalError.errorStateID != to_underlying(ErrorStateEnum::kNoError))
     {
         mOperationalError.Set(to_underlying(ErrorStateEnum::kNoError));
+        countdownTimeUpdateNeeded = true;
         MatterReportingAttributeChangeCallback(mEndpointId, mClusterId, Attributes::OperationalError::Id);
     }
 
@@ -104,6 +111,12 @@ CHIP_ERROR Instance::SetOperationalState(uint8_t aOpState)
     if (mOperationalState != oldState)
     {
         MatterReportingAttributeChangeCallback(mEndpointId, mClusterId, Attributes::OperationalState::Id);
+        countdownTimeUpdateNeeded = true;
+    }
+
+    if (countdownTimeUpdateNeeded)
+    {
+        UpdateCountdownTimeFromClusterLogic();
     }
     return CHIP_NO_ERROR;
 }
@@ -140,6 +153,8 @@ void Instance::OnOperationalErrorDetected(const Structs::ErrorStateStruct::Type 
         MatterReportingAttributeChangeCallback(mEndpointId, mClusterId, Attributes::OperationalError::Id);
     }
 
+    UpdateCountdownTimeFromClusterLogic();
+
     // Generate an ErrorDetected event
     GenericErrorEvent event(mClusterId, aError);
     EventNumber eventNumber;
@@ -153,7 +168,7 @@ void Instance::OnOperationalErrorDetected(const Structs::ErrorStateStruct::Type 
 
 void Instance::OnOperationCompletionDetected(uint8_t aCompletionErrorCode,
                                              const Optional<DataModel::Nullable<uint32_t>> & aTotalOperationalTime,
-                                             const Optional<DataModel::Nullable<uint32_t>> & aPausedTime) const
+                                             const Optional<DataModel::Nullable<uint32_t>> & aPausedTime)
 {
     ChipLogDetail(Zcl, "OperationalStateServer: OnOperationCompletionDetected");
 
@@ -166,6 +181,8 @@ void Instance::OnOperationCompletionDetected(uint8_t aCompletionErrorCode,
         ChipLogError(Zcl, "OperationalStateServer: Failed to record OperationCompletion event: %" CHIP_ERROR_FORMAT,
                      error.Format());
     }
+
+    UpdateCountdownTimeFromClusterLogic();
 }
 
 void Instance::ReportOperationalStateListChange()
@@ -176,6 +193,43 @@ void Instance::ReportOperationalStateListChange()
 void Instance::ReportPhaseListChange()
 {
     MatterReportingAttributeChangeCallback(ConcreteAttributePath(mEndpointId, mClusterId, Attributes::PhaseList::Id));
+    UpdateCountdownTimeFromClusterLogic();
+}
+
+void Instance::UpdateCountdownTime(bool fromDelegate)
+{
+    app::DataModel::Nullable<uint32_t> newCountdownTime = mDelegate->GetCountdownTime();
+    auto now                                            = System::SystemClock().GetMonotonicTimestamp();
+
+    bool markDirty = false;
+
+    if (fromDelegate)
+    {
+        // Updates from delegate are reduce-reported to every 10s max (choice of this implementation), in addition
+        // to default change-from-null, change-from-zero and increment policy.
+        auto predicate = [](const decltype(mCountdownTime)::SufficientChangePredicateCandidate & candidate) -> bool {
+            if (candidate.lastDirtyValue.IsNull() || candidate.newValue.IsNull())
+            {
+                return false;
+            }
+
+            uint32_t lastDirtyValue           = candidate.lastDirtyValue.Value();
+            uint32_t newValue                 = candidate.newValue.Value();
+            uint32_t kNumSecondsDeltaToReport = 10;
+            return (newValue < lastDirtyValue) && ((lastDirtyValue - newValue) > kNumSecondsDeltaToReport);
+        };
+        markDirty = (mCountdownTime.SetValue(newCountdownTime, now, predicate) == AttributeDirtyState::kMustReport);
+    }
+    else
+    {
+        auto predicate = [](const decltype(mCountdownTime)::SufficientChangePredicateCandidate &) -> bool { return true; };
+        markDirty      = (mCountdownTime.SetValue(newCountdownTime, now, predicate) == AttributeDirtyState::kMustReport);
+    }
+
+    if (markDirty)
+    {
+        MatterReportingAttributeChangeCallback(mEndpointId, mClusterId, Attributes::CountdownTime::Id);
+    }
 }
 
 bool Instance::IsSupportedPhase(uint8_t aPhase)
@@ -267,6 +321,7 @@ void Instance::InvokeCommand(HandlerContext & handlerContext)
         ChipLogDetail(Zcl, "OperationalState: Entering handling derived cluster commands");
 
         InvokeDerivedClusterCommand(handlerContext);
+        break;
     }
 }
 
@@ -291,18 +346,18 @@ CHIP_ERROR Instance::Read(const ConcreteReadAttributePath & aPath, AttributeValu
             }
             return err;
         });
+        break;
     }
-    break;
 
     case OperationalState::Attributes::OperationalState::Id: {
         ReturnErrorOnFailure(aEncoder.Encode(GetCurrentOperationalState()));
+        break;
     }
-    break;
 
     case OperationalState::Attributes::OperationalError::Id: {
         ReturnErrorOnFailure(aEncoder.Encode(mOperationalError));
+        break;
     }
-    break;
 
     case OperationalState::Attributes::PhaseList::Id: {
 
@@ -329,18 +384,19 @@ CHIP_ERROR Instance::Read(const ConcreteReadAttributePath & aPath, AttributeValu
                 ReturnErrorOnFailure(encoder.Encode(phase2));
             }
         });
+        break;
     }
-    break;
 
     case OperationalState::Attributes::CurrentPhase::Id: {
         ReturnErrorOnFailure(aEncoder.Encode(GetCurrentPhase()));
+        break;
     }
-    break;
 
     case OperationalState::Attributes::CountdownTime::Id: {
+        // Read through to get value closest to reality.
         ReturnErrorOnFailure(aEncoder.Encode(mDelegate->GetCountdownTime()));
+        break;
     }
-    break;
     }
     return CHIP_NO_ERROR;
 }

--- a/src/app/codegen-data-model/CodegenDataModel_Write.cpp
+++ b/src/app/codegen-data-model/CodegenDataModel_Write.cpp
@@ -1,0 +1,405 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#include <app/codegen-data-model/CodegenDataModel.h>
+
+#include <access/AccessControl.h>
+#include <app-common/zap-generated/attribute-type.h>
+#include <app/AttributeAccessInterface.h>
+#include <app/AttributeAccessInterfaceRegistry.h>
+#include <app/RequiredPrivilege.h>
+#include <app/codegen-data-model/EmberMetadata.h>
+#include <app/data-model/FabricScoped.h>
+#include <app/reporting/reporting.h>
+#include <app/util/af-types.h>
+#include <app/util/attribute-metadata.h>
+#include <app/util/attribute-storage-detail.h>
+#include <app/util/attribute-storage-null-handling.h>
+#include <app/util/attribute-table-detail.h>
+#include <app/util/attribute-table.h>
+#include <app/util/ember-io-storage.h>
+#include <app/util/ember-strings.h>
+#include <app/util/odd-sized-integers.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CodeUtils.h>
+
+#include <zap-generated/endpoint_config.h>
+
+namespace chip {
+namespace app {
+namespace {
+
+using namespace chip::app::Compatibility::Internal;
+
+/// Attempts to write via an attribute access interface (AAI)
+///
+/// If it returns a CHIP_ERROR, then this is a FINAL result (i.e. either failure or success)
+///
+/// If it returns std::nullopt, then there is no AAI to handle the given path
+/// and processing should figure out the value otherwise (generally from other ember data)
+std::optional<CHIP_ERROR> TryWriteViaAccessInterface(const ConcreteAttributePath & path, AttributeAccessInterface * aai,
+                                                     AttributeValueDecoder & decoder)
+{
+    // Processing can happen only if an attribute access interface actually exists..
+    if (aai == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    CHIP_ERROR err = aai->Write(path, decoder);
+
+    if (err != CHIP_NO_ERROR)
+    {
+        return std::make_optional(err);
+    }
+
+    // If the decoder tried to decode, then a value should have been read for processing.
+    //   - if decoding was done, assume DONE (i.e. final CHIP_NO_ERROR)
+    //   -  otherwise, if no decoding done, return that processing must continue via nullopt
+    return decoder.TriedDecode() ? std::make_optional(CHIP_NO_ERROR) : std::nullopt;
+}
+
+/// Metadata of what a ember/pascal short string means (prepended by a u8 length)
+struct ShortPascalString
+{
+    using LengthType                        = uint8_t;
+    static constexpr LengthType kNullLength = 0xFF;
+
+    static void SetLength(uint8_t * buffer, LengthType value) { *buffer = value; }
+};
+
+/// Metadata of what a ember/pascal LONG string means (prepended by a u16 length)
+struct LongPascalString
+{
+    using LengthType                        = uint16_t;
+    static constexpr LengthType kNullLength = 0xFFFF;
+
+    // Encoding for ember string lengths is little-endian (see ember-strings.cpp)
+    static void SetLength(uint8_t * buffer, LengthType value) { Encoding::LittleEndian::Put16(buffer, value); }
+};
+
+// ember assumptions ... should just work
+static_assert(sizeof(ShortPascalString::LengthType) == 1);
+static_assert(sizeof(LongPascalString::LengthType) == 2);
+
+/// Convert the value stored in 'decoder' into an ember format span 'out'
+///
+/// The value converted will be of type T (e.g. CharSpan or ByteSpan) and it will be converted
+/// via the given ENCODING (i.e. ShortPascalString or LongPascalString)
+///
+/// isNullable defines if the value of NULL is allowed to be converted.
+template <typename T, class ENCODING>
+CHIP_ERROR DecodeStringLikeIntoEmberBuffer(AttributeValueDecoder decoder, bool isNullable, MutableByteSpan & out)
+{
+    T workingValue;
+
+    if (isNullable)
+    {
+        typename DataModel::Nullable<T> nullableWorkingValue;
+        ReturnErrorOnFailure(decoder.Decode(nullableWorkingValue));
+
+        if (nullableWorkingValue.IsNull())
+        {
+            VerifyOrReturnError(out.size() >= sizeof(typename ENCODING::LengthType), CHIP_ERROR_BUFFER_TOO_SMALL);
+            ENCODING::SetLength(out.data(), ENCODING::kNullLength);
+            out.reduce_size(sizeof(typename ENCODING::LengthType));
+            return CHIP_NO_ERROR;
+        }
+
+        // continue encoding non-null value
+        workingValue = nullableWorkingValue.Value();
+    }
+    else
+    {
+        ReturnErrorOnFailure(decoder.Decode(workingValue));
+    }
+
+    auto len = static_cast<typename ENCODING::LengthType>(workingValue.size());
+    VerifyOrReturnError(out.size() >= sizeof(len) + len, CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    uint8_t * output_buffer = out.data();
+
+    ENCODING::SetLength(output_buffer, len);
+    output_buffer += sizeof(len);
+
+    memcpy(output_buffer, workingValue.data(), workingValue.size());
+    output_buffer += workingValue.size();
+
+    out.reduce_size(static_cast<size_t>(output_buffer - out.data()));
+    return CHIP_NO_ERROR;
+}
+
+/// Decodes a numeric data value of type T from the `decoder` into a ember-encoded buffer `out`
+///
+/// isNullable defines if the value of NULL is allowed to be decoded.
+template <typename T>
+CHIP_ERROR DecodeIntoEmberBuffer(AttributeValueDecoder & decoder, bool isNullable, MutableByteSpan & out)
+{
+    using Traits = NumericAttributeTraits<T>;
+    typename Traits::StorageType storageValue;
+
+    if (isNullable)
+    {
+        DataModel::Nullable<typename Traits::WorkingType> workingValue;
+        ReturnErrorOnFailure(decoder.Decode(workingValue));
+
+        if (workingValue.IsNull())
+        {
+            Traits::SetNull(storageValue);
+        }
+        else
+        {
+            // This guards against trying to decode something that overlaps nullable, for example
+            // Nullable<uint8_t>(0xFF) is not representable because 0xFF is the encoding of NULL in ember
+            // as well as odd-sized integers (e.g. full 32-bit value like 0x11223344 cannot be written
+            // to a 3-byte odd-sized integger).
+            VerifyOrReturnError(Traits::CanRepresentValue(isNullable, workingValue.Value()), CHIP_ERROR_INVALID_ARGUMENT);
+            Traits::WorkingToStorage(workingValue.Value(), storageValue);
+        }
+
+        VerifyOrReturnError(out.size() >= sizeof(storageValue), CHIP_ERROR_INVALID_ARGUMENT);
+    }
+    else
+    {
+        typename Traits::WorkingType workingValue;
+        ReturnErrorOnFailure(decoder.Decode(workingValue));
+
+        Traits::WorkingToStorage(workingValue, storageValue);
+
+        VerifyOrReturnError(out.size() >= sizeof(storageValue), CHIP_ERROR_INVALID_ARGUMENT);
+
+        // Even non-nullable values may be outside range: e.g. odd-sized integers have working values
+        // that are larger than the storage values (e.g. a uint32_t being stored as a 3-byte integer)
+        VerifyOrReturnError(Traits::CanRepresentValue(isNullable, workingValue), CHIP_ERROR_INVALID_ARGUMENT);
+    }
+
+    const uint8_t * data = Traits::ToAttributeStoreRepresentation(storageValue);
+
+    // The decoding + ToAttributeStoreRepresentation will result in data being
+    // stored in native format/byteorder, suitable to directly be stored in the data store
+    memcpy(out.data(), data, sizeof(storageValue));
+    out.reduce_size(sizeof(storageValue));
+
+    return CHIP_NO_ERROR;
+}
+
+/// Read the data from "decoder" into an ember-formatted buffer "out"
+///
+/// `out` is a in/out buffer:
+///    - its initial size determines the maximum size of the buffer
+///    - its output size reflects the actual data size
+///
+/// Uses the attribute `metadata` to determine how the data is to be encoded into out.
+CHIP_ERROR DecodeValueIntoEmberBuffer(AttributeValueDecoder & decoder, const EmberAfAttributeMetadata * metadata,
+                                      MutableByteSpan & out)
+{
+    VerifyOrReturnError(metadata != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    const bool isNullable = metadata->IsNullable();
+
+    switch (AttributeBaseType(metadata->attributeType))
+    {
+    case ZCL_BOOLEAN_ATTRIBUTE_TYPE: // Boolean
+        return DecodeIntoEmberBuffer<bool>(decoder, isNullable, out);
+    case ZCL_INT8U_ATTRIBUTE_TYPE: // Unsigned 8-bit integer
+        return DecodeIntoEmberBuffer<uint8_t>(decoder, isNullable, out);
+    case ZCL_INT16U_ATTRIBUTE_TYPE: // Unsigned 16-bit integer
+        return DecodeIntoEmberBuffer<uint16_t>(decoder, isNullable, out);
+    case ZCL_INT24U_ATTRIBUTE_TYPE: // Unsigned 24-bit integer
+        return DecodeIntoEmberBuffer<OddSizedInteger<3, false>>(decoder, isNullable, out);
+    case ZCL_INT32U_ATTRIBUTE_TYPE: // Unsigned 32-bit integer
+        return DecodeIntoEmberBuffer<uint32_t>(decoder, isNullable, out);
+    case ZCL_INT40U_ATTRIBUTE_TYPE: // Unsigned 40-bit integer
+        return DecodeIntoEmberBuffer<OddSizedInteger<5, false>>(decoder, isNullable, out);
+    case ZCL_INT48U_ATTRIBUTE_TYPE: // Unsigned 48-bit integer
+        return DecodeIntoEmberBuffer<OddSizedInteger<6, false>>(decoder, isNullable, out);
+    case ZCL_INT56U_ATTRIBUTE_TYPE: // Unsigned 56-bit integer
+        return DecodeIntoEmberBuffer<OddSizedInteger<7, false>>(decoder, isNullable, out);
+    case ZCL_INT64U_ATTRIBUTE_TYPE: // Unsigned 64-bit integer
+        return DecodeIntoEmberBuffer<uint64_t>(decoder, isNullable, out);
+    case ZCL_INT8S_ATTRIBUTE_TYPE: // Signed 8-bit integer
+        return DecodeIntoEmberBuffer<int8_t>(decoder, isNullable, out);
+    case ZCL_INT16S_ATTRIBUTE_TYPE: // Signed 16-bit integer
+        return DecodeIntoEmberBuffer<int16_t>(decoder, isNullable, out);
+    case ZCL_INT24S_ATTRIBUTE_TYPE: // Signed 24-bit integer
+        return DecodeIntoEmberBuffer<OddSizedInteger<3, true>>(decoder, isNullable, out);
+    case ZCL_INT32S_ATTRIBUTE_TYPE: // Signed 32-bit integer
+        return DecodeIntoEmberBuffer<int32_t>(decoder, isNullable, out);
+    case ZCL_INT40S_ATTRIBUTE_TYPE: // Signed 40-bit integer
+        return DecodeIntoEmberBuffer<OddSizedInteger<5, true>>(decoder, isNullable, out);
+    case ZCL_INT48S_ATTRIBUTE_TYPE: // Signed 48-bit integer
+        return DecodeIntoEmberBuffer<OddSizedInteger<6, true>>(decoder, isNullable, out);
+    case ZCL_INT56S_ATTRIBUTE_TYPE: // Signed 56-bit integer
+        return DecodeIntoEmberBuffer<OddSizedInteger<7, true>>(decoder, isNullable, out);
+    case ZCL_INT64S_ATTRIBUTE_TYPE: // Signed 64-bit integer
+        return DecodeIntoEmberBuffer<int64_t>(decoder, isNullable, out);
+    case ZCL_SINGLE_ATTRIBUTE_TYPE: // 32-bit float
+        return DecodeIntoEmberBuffer<float>(decoder, isNullable, out);
+    case ZCL_DOUBLE_ATTRIBUTE_TYPE: // 64-bit float
+        return DecodeIntoEmberBuffer<double>(decoder, isNullable, out);
+    case ZCL_CHAR_STRING_ATTRIBUTE_TYPE: // Char string
+        return DecodeStringLikeIntoEmberBuffer<CharSpan, ShortPascalString>(decoder, isNullable, out);
+    case ZCL_LONG_CHAR_STRING_ATTRIBUTE_TYPE:
+        return DecodeStringLikeIntoEmberBuffer<CharSpan, LongPascalString>(decoder, isNullable, out);
+    case ZCL_OCTET_STRING_ATTRIBUTE_TYPE: // Octet string
+        return DecodeStringLikeIntoEmberBuffer<ByteSpan, ShortPascalString>(decoder, isNullable, out);
+    case ZCL_LONG_OCTET_STRING_ATTRIBUTE_TYPE:
+        return DecodeStringLikeIntoEmberBuffer<ByteSpan, LongPascalString>(decoder, isNullable, out);
+    default:
+        ChipLogError(DataManagement, "Attribute type 0x%x not handled", static_cast<int>(metadata->attributeType));
+        return CHIP_IM_GLOBAL_STATUS(Failure);
+    }
+}
+
+} // namespace
+
+CHIP_ERROR CodegenDataModel::WriteAttribute(const InteractionModel::WriteAttributeRequest & request,
+                                            AttributeValueDecoder & decoder)
+{
+    ChipLogDetail(DataManagement, "Writing attribute: Cluster=" ChipLogFormatMEI " Endpoint=0x%x AttributeId=" ChipLogFormatMEI,
+                  ChipLogValueMEI(request.path.mClusterId), request.path.mEndpointId, ChipLogValueMEI(request.path.mAttributeId));
+
+    // ACL check for non-internal requests
+    if (!request.operationFlags.Has(InteractionModel::OperationFlags::kInternal))
+    {
+        ReturnErrorCodeIf(!request.subjectDescriptor.has_value(), CHIP_IM_GLOBAL_STATUS(UnsupportedAccess));
+
+        Access::RequestPath requestPath{ .cluster = request.path.mClusterId, .endpoint = request.path.mEndpointId };
+        CHIP_ERROR err = Access::GetAccessControl().Check(*request.subjectDescriptor, requestPath,
+                                                          RequiredPrivilege::ForWriteAttribute(request.path));
+
+        if (err != CHIP_NO_ERROR)
+        {
+            ReturnErrorCodeIf(err != CHIP_ERROR_ACCESS_DENIED, err);
+
+            // TODO: when wildcard/group writes are supported, handle them to discard rather than fail with status
+            return CHIP_IM_GLOBAL_STATUS(UnsupportedAccess);
+        }
+    }
+
+    auto metadata = Ember::FindAttributeMetadata(request.path);
+
+    if (const CHIP_ERROR * err = std::get_if<CHIP_ERROR>(&metadata))
+    {
+        VerifyOrDie((*err == CHIP_IM_GLOBAL_STATUS(UnsupportedEndpoint)) || //
+                    (*err == CHIP_IM_GLOBAL_STATUS(UnsupportedCluster)) ||  //
+                    (*err == CHIP_IM_GLOBAL_STATUS(UnsupportedAttribute)));
+        return *err;
+    }
+
+    const EmberAfAttributeMetadata ** attributeMetadata = std::get_if<const EmberAfAttributeMetadata *>(&metadata);
+
+    // All the global attributes that we do not have metadata for are
+    // read-only. Specifically only the following list-based attributes match the
+    // "global attributes not in metadata" (see GlobalAttributes.h :: GlobalAttributesNotInMetadata):
+    //   - AttributeList
+    //   - EventList
+    //   - AcceptedCommands
+    //   - GeneratedCommands
+    //
+    // Given the above, UnsupportedWrite should be correct (attempt to write to a read-only list)
+    bool isReadOnly = (attributeMetadata == nullptr) || (*attributeMetadata)->IsReadOnly();
+
+    // Internal is allowed to bypass timed writes and read-only.
+    if (!request.operationFlags.Has(InteractionModel::OperationFlags::kInternal))
+    {
+        VerifyOrReturnError(!isReadOnly, CHIP_IM_GLOBAL_STATUS(UnsupportedWrite));
+
+        VerifyOrReturnError(!(*attributeMetadata)->MustUseTimedWrite() ||
+                                request.writeFlags.Has(InteractionModel::WriteFlags::kTimed),
+                            CHIP_IM_GLOBAL_STATUS(NeedsTimedInteraction));
+    }
+
+    // Extra check: internal requests can bypass the read only check, however global attributes
+    // have no underlying storage, so write still cannot be done
+    VerifyOrReturnError(attributeMetadata != nullptr, CHIP_IM_GLOBAL_STATUS(UnsupportedWrite));
+
+    if (request.path.mDataVersion.HasValue())
+    {
+        std::optional<InteractionModel::ClusterInfo> clusterInfo = GetClusterInfo(request.path);
+        if (!clusterInfo.has_value())
+        {
+            ChipLogError(DataManagement, "Unable to get cluster info for Endpoint 0x%x, Cluster " ChipLogFormatMEI,
+                         request.path.mEndpointId, ChipLogValueMEI(request.path.mClusterId));
+            return CHIP_IM_GLOBAL_STATUS(DataVersionMismatch);
+        }
+
+        if (request.path.mDataVersion.Value() != clusterInfo->dataVersion)
+        {
+            ChipLogError(DataManagement, "Write Version mismatch for Endpoint 0x%x, Cluster " ChipLogFormatMEI,
+                         request.path.mEndpointId, ChipLogValueMEI(request.path.mClusterId));
+            return CHIP_IM_GLOBAL_STATUS(DataVersionMismatch);
+        }
+    }
+
+    AttributeAccessInterface * aai       = GetAttributeAccessOverride(request.path.mEndpointId, request.path.mClusterId);
+    std::optional<CHIP_ERROR> aai_result = TryWriteViaAccessInterface(request.path, aai, decoder);
+    if (aai_result.has_value())
+    {
+        if (*aai_result == CHIP_NO_ERROR)
+        {
+            // TODO: change callbacks should likely be routed through the context `MarkDirty` only
+            //       however for now this is called directly because ember code does this call
+            //       inside emberAfWriteAttribute.
+            MatterReportingAttributeChangeCallback(request.path);
+            CurrentContext().dataModelChangeListener->MarkDirty(request.path);
+        }
+        return *aai_result;
+    }
+
+    MutableByteSpan dataBuffer = gEmberAttributeIOBufferSpan;
+    ReturnErrorOnFailure(DecodeValueIntoEmberBuffer(decoder, *attributeMetadata, dataBuffer));
+
+    Protocols::InteractionModel::Status status;
+
+    if (dataBuffer.size() > (*attributeMetadata)->size)
+    {
+        ChipLogDetail(Zcl, "Data to write exceeds the attribute size claimed.");
+        return CHIP_IM_GLOBAL_STATUS(InvalidValue);
+    }
+
+    if (request.operationFlags.Has(InteractionModel::OperationFlags::kInternal))
+    {
+        // Internal requests use the non-External interface that has less enforcement
+        // than the external version (e.g. does not check/enforce writable settings, does not
+        // validate attribute types) - see attribute-table.h documentation for details.
+        status = emberAfWriteAttribute(request.path.mEndpointId, request.path.mClusterId, request.path.mAttributeId,
+                                       dataBuffer.data(), (*attributeMetadata)->attributeType);
+    }
+    else
+    {
+        status = emAfWriteAttributeExternal(request.path.mEndpointId, request.path.mClusterId, request.path.mAttributeId,
+                                            dataBuffer.data(), (*attributeMetadata)->attributeType);
+    }
+
+    if (status != Protocols::InteractionModel::Status::Success)
+    {
+        return CHIP_ERROR_IM_GLOBAL_STATUS_VALUE(status);
+    }
+
+    // TODO: this WILL requre updates
+    //
+    // - Internal writes may need to be able to decide if to mark things dirty or not (see AAI as well)
+    // - Changes-ommited paths should not be marked dirty (ember is not aware of that flag)
+    // - This likely maps to `MatterReportingAttributeChangeCallback` HOWEVER current ember write functions
+    //   will selectively call that one depending on old attribute state (i.e. calling every time is a
+    //   change in behavior)
+    CurrentContext().dataModelChangeListener->MarkDirty(request.path);
+    return CHIP_NO_ERROR;
+}
+
+} // namespace app
+} // namespace chip

--- a/src/python_testing/TC_OpstateCommon.py
+++ b/src/python_testing/TC_OpstateCommon.py
@@ -354,7 +354,7 @@ class TC_OPSTATE_BASE():
             if phase_list is not NullValue:
                 phase_list_len = len(phase_list)
                 asserts.assert_less_equal(phase_list_len, 32,
-                                          f"PhaseList length({phase_list_len}) must be less than 32!")
+                                          f"PhaseList length({phase_list_len}) must be at most 32 entries!")
 
         # STEP 3: TH reads from the DUT the CurrentPhase attribute
         self.step(3)
@@ -364,8 +364,9 @@ class TC_OPSTATE_BASE():
             if (phase_list == NullValue) or (not phase_list):
                 asserts.assert_true(current_phase == NullValue, f"CurrentPhase({current_phase}) should be null")
             else:
-                asserts.assert_true(0 <= current_phase and current_phase < phase_list_len,
-                                    f"CurrentPhase({current_phase}) must be between 0 and {(phase_list_len - 1)}")
+                asserts.assert_greater_equal(current_phase, 0, f"CurrentPhase({current_phase}) must be >= 0")
+                asserts.assert_less(current_phase, phase_list_len,
+                                    f"CurrentPhase({current_phase}) must be less than {phase_list_len}")
 
         # STEP 4: TH reads from the DUT the CountdownTime attribute
         self.step(4)
@@ -652,7 +653,7 @@ class TC_OPSTATE_BASE():
             if phase_list is not NullValue:
                 phase_list_len = len(phase_list)
                 asserts.assert_less_equal(phase_list_len, 32,
-                                          f"PhaseList length({phase_list_len}) must be less than 32!")
+                                          f"PhaseList length({phase_list_len}) must be at most 32 entries!")
 
         # STEP 9: TH reads from the DUT the CurrentPhase attribute
         self.step(9)
@@ -662,10 +663,10 @@ class TC_OPSTATE_BASE():
             if (phase_list == NullValue) or (not phase_list):
                 asserts.assert_equal(current_phase, NullValue, f"CurrentPhase({current_phase}) should be null")
             else:
-                asserts.assert_less_equal(0, current_phase,
-                                          f"CurrentPhase({current_phase}) must be greater or equal than 0")
-                asserts.assert_less(current_phase < phase_list_len,
-                                    f"CurrentPhase({current_phase}) must be less then {(phase_list_len - 1)}")
+                asserts.assert_greater_equal(current_phase, 0,
+                                             f"CurrentPhase({current_phase}) must be greater or equal to 0")
+                asserts.assert_less(current_phase, phase_list_len,
+                                    f"CurrentPhase({current_phase}) must be less than {(phase_list_len)}")
 
         # STEP 10: TH waits for {PIXIT.WAITTIME.COUNTDOWN}
         self.step(10)
@@ -679,6 +680,8 @@ class TC_OPSTATE_BASE():
                                                             attribute=attributes.CountdownTime)
 
             if (countdown_time is not NullValue) and (initial_countdown_time is not NullValue):
+                logging.info(f" -> Initial countdown time: {initial_countdown_time}")
+                logging.info(f" -> New countdown time: {countdown_time}")
                 asserts.assert_less_equal(countdown_time, (initial_countdown_time - wait_time),
                                           f"The countdown time shall have decreased at least {wait_time:.1f} since start command")
 
@@ -821,6 +824,7 @@ class TC_OPSTATE_BASE():
             initial_countdown_time = await self.read_expect_success(endpoint=endpoint,
                                                                     attribute=attributes.CountdownTime)
             if initial_countdown_time is not NullValue:
+                logging.info(f" -> Initial ountdown time: {initial_countdown_time}")
                 asserts.assert_true(0 <= initial_countdown_time <= 259200,
                                     f"CountdownTime({initial_countdown_time}) must be between 0 and 259200")
 
@@ -835,6 +839,8 @@ class TC_OPSTATE_BASE():
                                                             attribute=attributes.CountdownTime)
 
             if (countdown_time is not NullValue) and (initial_countdown_time is not NullValue):
+                logging.info(f" -> Initial countdown time: {initial_countdown_time}")
+                logging.info(f" -> New countdown time: {countdown_time}")
                 asserts.assert_equal(countdown_time, initial_countdown_time,
                                      "The countdown time shall be equal since pause command")
 


### PR DESCRIPTION
Cherry-pick #35271 to support `GetCountdownTime` in `OperationalState` cluster and related PRs 
